### PR TITLE
Add puzzle web app with container setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# teste-cicada
+# Teste Cicada
+
+Este projeto é um exemplo simples de site de enigmas inspirado no estilo Cicada 3301. São cinco enigmas sequenciais que só podem ser acessados após a resolução do anterior.
+
+## Como executar localmente
+
+1. Instale as dependências (é necessário ter o Node.js instalado):
+   ```bash
+   npm install
+   ```
+2. Inicie o servidor:
+   ```bash
+   npm start
+   ```
+   O aplicativo ficará disponível em `http://localhost:3000`.
+
+## Utilizando Docker
+
+É possível executar o projeto em um container Docker:
+
+```bash
+# Construir a imagem
+docker build -t cicada-web .
+
+# Executar o container
+docker run -p 3000:3000 cicada-web
+```
+
+## Implantação no Kubernetes
+
+Um manifesto de exemplo está disponível em `k8s/deployment.yaml`.
+Para implantar no cluster:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+
+Isso criará um Deployment e um Service expondo o aplicativo internamente na porta 80.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cicada-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cicada-web
+  template:
+    metadata:
+      labels:
+        app: cicada-web
+    spec:
+      containers:
+      - name: cicada-web
+        image: cicada-web:latest
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cicada-web
+spec:
+  type: ClusterIP
+  selector:
+    app: cicada-web
+  ports:
+  - port: 80
+    targetPort: 3000

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "teste-cicada",
+  "version": "1.0.0",
+  "description": "Puzzle challenge website",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "ejs": "^3.1.8"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,68 @@
+const express = require('express');
+const session = require('express-session');
+const path = require('path');
+
+const app = express();
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(__dirname, 'views'));
+
+app.use(express.urlencoded({ extended: true }));
+app.use(session({
+  secret: 'cicada-secret',
+  resave: false,
+  saveUninitialized: true
+}));
+
+const puzzles = [
+  { question: 'Enigma 1: Qual a palavra secreta?', answer: 'cicada' },
+  { question: 'Enigma 2: 2 + 2 = ?', answer: '4' },
+  { question: 'Enigma 3: Primeiro nome do criador do Linux?', answer: 'linus' },
+  { question: 'Enigma 4: Que linguagem executa no navegador?', answer: 'javascript' },
+  { question: 'Enigma 5: Complete: Hello ____!', answer: 'world' }
+];
+
+function ensureLevel(level) {
+  return function(req, res, next) {
+    if ((req.session.level || 0) >= level) {
+      next();
+    } else {
+      res.redirect(`/puzzle${req.session.level || 1}`);
+    }
+  };
+}
+
+app.get('/', (req, res) => {
+  req.session.level = req.session.level || 1;
+  res.redirect(`/puzzle${req.session.level}`);
+});
+
+puzzles.forEach((puzzle, index) => {
+  const level = index + 1;
+  app.get(`/puzzle${level}`, ensureLevel(level), (req, res) => {
+    res.render('puzzle', { question: puzzle.question, level });
+  });
+
+  app.post(`/puzzle${level}`, ensureLevel(level), (req, res) => {
+    const answer = (req.body.answer || '').trim().toLowerCase();
+    if (answer === puzzle.answer) {
+      req.session.level = level + 1;
+      if (level === puzzles.length) {
+        res.redirect('/completed');
+      } else {
+        res.redirect(`/puzzle${level + 1}`);
+      }
+    } else {
+      res.render('puzzle', { question: puzzle.question, level, error: 'Resposta incorreta.' });
+    }
+  });
+});
+
+app.get('/completed', ensureLevel(puzzles.length + 1), (req, res) => {
+  res.send('<h1>Parabéns! Você completou todos os enigmas.</h1>');
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Servidor rodando na porta ${port}`);
+});

--- a/views/puzzle.ejs
+++ b/views/puzzle.ejs
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <title>Enigma <%= level %></title>
+</head>
+<body>
+  <h1><%= question %></h1>
+  <% if (typeof error !== 'undefined') { %>
+    <p style="color:red;"><%= error %></p>
+  <% } %>
+  <form method="post">
+    <input type="text" name="answer" autofocus required>
+    <button type="submit">Enviar</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement simple Node/Express puzzle app with sessions
- add puzzle template view
- provide Dockerfile and Kubernetes manifest
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68707d262754832db735d0b383d19835