### PR TITLE
Improve puzzle UI with hints

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,11 +15,36 @@ app.use(session({
 }));
 
 const puzzles = [
-  { question: 'Enigma 1: Qual a palavra secreta?', answer: 'cicada' },
-  { question: 'Enigma 2: 2 + 2 = ?', answer: '4' },
-  { question: 'Enigma 3: Primeiro nome do criador do Linux?', answer: 'linus' },
-  { question: 'Enigma 4: Que linguagem executa no navegador?', answer: 'javascript' },
-  { question: 'Enigma 5: Complete: Hello ____!', answer: 'world' }
+  {
+    question: 'Enigma 1: Qual a palavra secreta?',
+    answer: 'cicada',
+    image:
+      'https://images.unsplash.com/photo-1610026802263-92d7b3d21404?auto=format&fit=crop&w=600&q=60',
+  },
+  {
+    question: 'Enigma 2: 2 + 2 = ?',
+    answer: '4',
+    image:
+      'https://images.unsplash.com/photo-1571158136638-d7aa1bf116c5?auto=format&fit=crop&w=600&q=60',
+  },
+  {
+    question: 'Enigma 3: Primeiro nome do criador do Linux?',
+    answer: 'linus',
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/3/3f/Linus_Torvalds_2018.jpg',
+  },
+  {
+    question: 'Enigma 4: Que linguagem executa no navegador?',
+    answer: 'javascript',
+    image:
+      'https://upload.wikimedia.org/wikipedia/commons/9/99/Unofficial_JavaScript_logo_2.svg',
+  },
+  {
+    question: 'Enigma 5: Complete: Hello ____!',
+    answer: 'world',
+    image:
+      'https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?auto=format&fit=crop&w=600&q=60',
+  },
 ];
 
 function ensureLevel(level) {
@@ -40,7 +65,7 @@ app.get('/', (req, res) => {
 puzzles.forEach((puzzle, index) => {
   const level = index + 1;
   app.get(`/puzzle${level}`, ensureLevel(level), (req, res) => {
-    res.render('puzzle', { question: puzzle.question, level });
+    res.render('puzzle', { question: puzzle.question, level, image: puzzle.image });
   });
 
   app.post(`/puzzle${level}`, ensureLevel(level), (req, res) => {
@@ -53,7 +78,12 @@ puzzles.forEach((puzzle, index) => {
         res.redirect(`/puzzle${level + 1}`);
       }
     } else {
-      res.render('puzzle', { question: puzzle.question, level, error: 'Resposta incorreta.' });
+      res.render('puzzle', {
+        question: puzzle.question,
+        level,
+        error: 'Resposta incorreta.',
+        image: puzzle.image,
+      });
     }
   });
 });

--- a/views/puzzle.ejs
+++ b/views/puzzle.ejs
@@ -1,17 +1,48 @@
 <!DOCTYPE html>
 <html lang="pt-br">
-<head>
-  <meta charset="UTF-8">
-  <title>Enigma <%= level %></title>
-</head>
-<body>
-  <h1><%= question %></h1>
-  <% if (typeof error !== 'undefined') { %>
-    <p style="color:red;"><%= error %></p>
-  <% } %>
-  <form method="post">
-    <input type="text" name="answer" autofocus required>
-    <button type="submit">Enviar</button>
-  </form>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Enigma <%= level %></title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+    />
+    <style>
+      body {
+        background-color: #f5f5f5;
+      }
+      .puzzle-container {
+        max-width: 600px;
+        margin: 50px auto;
+        padding: 20px;
+        background: #fff;
+        border-radius: 8px;
+        text-align: center;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+      }
+      img.hint {
+        max-width: 100%;
+        height: auto;
+        margin-bottom: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="puzzle-container">
+      <h1 class="h4 mb-4">Enigma <%= level %></h1>
+      <% if (image) { %>
+      <img src="<%= image %>" alt="dica" class="hint" />
+      <% } %>
+      <p class="mb-4"><%= question %></p>
+      <% if (typeof error !== 'undefined') { %>
+      <p class="text-danger"><%= error %></p>
+      <% } %>
+      <form method="post">
+        <div class="input-group mb-3">
+          <input class="form-control" type="text" name="answer" autofocus required />
+          <button class="btn btn-primary" type="submit">Enviar</button>
+        </div>
+      </form>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add hint images to the puzzle definitions
- show images and style each puzzle page

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68707e8903e0832da3515e176a4329ab