### PR TITLE
Improve puzzle and final screens

### DIFF
--- a/server.js
+++ b/server.js
@@ -89,7 +89,7 @@ puzzles.forEach((puzzle, index) => {
 });
 
 app.get('/completed', ensureLevel(puzzles.length + 1), (req, res) => {
-  res.send('<h1>Parabéns! Você completou todos os enigmas.</h1>');
+  res.render('completed');
 });
 
 const port = process.env.PORT || 3000;

--- a/views/completed.ejs
+++ b/views/completed.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Fim do Desafio</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel&display=swap" rel="stylesheet">
+    <style>
+      body {
+        background: url('https://images.unsplash.com/photo-1520218508822-4adfcca7d1f3?auto=format&fit=crop&w=1950&q=80') no-repeat center center fixed;
+        background-size: cover;
+        color: #eee;
+        font-family: 'Cinzel', serif;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      .final-container {
+        background: rgba(0, 0, 0, 0.8);
+        padding: 40px;
+        border-radius: 8px;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="final-container">
+      <h1 class="mb-4">Parabéns!</h1>
+      <p>Você desvendou todos os enigmas. Todo fim é apenas um novo começo.</p>
+    </div>
+  </body>
+</html>

--- a/views/puzzle.ejs
+++ b/views/puzzle.ejs
@@ -7,23 +7,36 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
     />
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel&family=Roboto+Mono&display=swap" rel="stylesheet">
     <style>
       body {
-        background-color: #f5f5f5;
+        background: radial-gradient(circle at top, #000, #111);
+        color: #eee;
+        font-family: 'Roboto Mono', monospace;
       }
       .puzzle-container {
         max-width: 600px;
-        margin: 50px auto;
-        padding: 20px;
-        background: #fff;
+        margin: 60px auto;
+        padding: 30px;
+        background: rgba(0, 0, 0, 0.85);
         border-radius: 8px;
         text-align: center;
-        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+      }
+      .puzzle-container h1 {
+        font-family: 'Cinzel', serif;
+        margin-bottom: 1rem;
       }
       img.hint {
         max-width: 100%;
         height: auto;
         margin-bottom: 15px;
+        border-radius: 4px;
+      }
+      input.form-control {
+        background-color: #222;
+        border: 1px solid #555;
+        color: #eee;
       }
     </style>
   </head>
@@ -40,7 +53,7 @@
       <form method="post">
         <div class="input-group mb-3">
           <input class="form-control" type="text" name="answer" autofocus required />
-          <button class="btn btn-primary" type="submit">Enviar</button>
+          <button class="btn btn-outline-light" type="submit">Enviar</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- style puzzle pages with a darker theme and dramatic fonts
- add a dramatic final page and render it at the end

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6871d05535bc832db86ed86d2ad5d740