### PR TITLE
Add intro page explaining puzzles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teste Cicada
 
-Este projeto é um exemplo simples de site de enigmas inspirado no estilo Cicada 3301. São cinco enigmas sequenciais que só podem ser acessados após a resolução do anterior.
+Este projeto é um exemplo simples de site de enigmas inspirado no estilo Cicada 3301. São cinco enigmas sequenciais que só podem ser acessados após a resolução do anterior. Ao abrir o endereço inicial (`/`) você verá uma tela introdutória com instruções e um botão **Iniciar** para avançar para o primeiro desafio.
 
 ## Como executar localmente
 

--- a/server.js
+++ b/server.js
@@ -58,8 +58,8 @@ function ensureLevel(level) {
 }
 
 app.get('/', (req, res) => {
-  req.session.level = req.session.level || 1;
-  res.redirect(`/puzzle${req.session.level}`);
+  req.session.level = 1;
+  res.render('index');
 });
 
 puzzles.forEach((puzzle, index) => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Bem-vindo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel&family=Roboto+Mono&display=swap" rel="stylesheet">
+    <style>
+      body {
+        background: radial-gradient(circle at top, #000, #111);
+        color: #eee;
+        font-family: 'Roboto Mono', monospace;
+        height: 100vh;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      .intro-container {
+        max-width: 700px;
+        background: rgba(0,0,0,0.85);
+        padding: 40px;
+        border-radius: 8px;
+        text-align: center;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+      }
+      h1 {
+        font-family: 'Cinzel', serif;
+        margin-bottom: 1rem;
+      }
+      a.btn-start {
+        margin-top: 20px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="intro-container">
+      <h1>Decifre se for capaz</h1>
+      <p>
+        Dizem que os sinais sussurram por toda parte, esperando por olhos atenciosos.
+        Nesta jornada cada enigma guarda a chave para o próximo. Observe as imagens,
+        leia nas entrelinhas e descubra o padrão oculto. Escreva sempre sua resposta
+        em letras minúsculas, sem acentos, e apenas a solução correta permitirá avançar.
+      </p>
+      <p>
+        Se estiver pronto para mergulhar no desconhecido, clique em iniciar e
+        dê o primeiro passo.
+      </p>
+      <a class="btn btn-outline-light btn-start" href="/puzzle1">Iniciar</a>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add mysterious intro page with instructions
- render intro at `/` route
- mention intro screen in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6872d029a744832d9e34a8000a7c35eb