### PR TITLE
Add mute control for background music

### DIFF
--- a/views/completed.ejs
+++ b/views/completed.ejs
@@ -23,15 +23,33 @@
         text-align: center;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
       }
+      #toggle-music {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+      }
     </style>
   </head>
   <body>
     <audio id="bg-music" autoplay loop style="display:none">
       <source src="https://cdn.pixabay.com/download/audio/2022/02/18/audio_e963615989.mp3?filename=suspense-6589.mp3" type="audio/mpeg">
     </audio>
+    <button id="toggle-music" class="btn btn-sm btn-outline-light">Silenciar</button>
     <div class="final-container">
       <h1 class="mb-4">Parabéns!</h1>
       <p>Você desvendou todos os enigmas. Todo fim é apenas um novo começo.</p>
     </div>
+    <script>
+      const music = document.getElementById('bg-music');
+      const btn = document.getElementById('toggle-music');
+      function setMute(m) {
+        music.muted = m;
+        btn.textContent = m ? 'Ativar Som' : 'Silenciar';
+        localStorage.setItem('music-muted', m);
+      }
+      btn.addEventListener('click', () => setMute(!music.muted));
+      const saved = localStorage.getItem('music-muted') === 'true';
+      setMute(saved);
+    </script>
   </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -27,8 +27,13 @@
         font-family: 'Cinzel', serif;
         margin-bottom: 1rem;
       }
-      a.btn-start {
+    a.btn-start {
         margin-top: 20px;
+      }
+      #toggle-music {
+        position: fixed;
+        top: 10px;
+        right: 10px;
       }
     </style>
   </head>
@@ -36,6 +41,7 @@
     <audio id="bg-music" autoplay loop style="display:none">
       <source src="https://cdn.pixabay.com/download/audio/2022/02/18/audio_e963615989.mp3?filename=suspense-6589.mp3" type="audio/mpeg">
     </audio>
+    <button id="toggle-music" class="btn btn-sm btn-outline-light">Silenciar</button>
     <div class="intro-container">
       <h1>Decifre se for capaz</h1>
       <p>
@@ -48,7 +54,19 @@
         Se estiver pronto para mergulhar no desconhecido, clique em iniciar e
         dê o primeiro passo.
       </p>
-      <a class="btn btn-outline-light btn-start" href="/puzzle1">Iniciar</a>
+    <a class="btn btn-outline-light btn-start" href="/puzzle1">Iniciar</a>
     </div>
+    <script>
+      const music = document.getElementById('bg-music');
+      const btn = document.getElementById('toggle-music');
+      function setMute(m){
+        music.muted = m;
+        btn.textContent = m ? 'Ativar Som' : 'Silenciar';
+        localStorage.setItem('music-muted', m);
+      }
+      btn.addEventListener('click', () => setMute(!music.muted));
+      const saved = localStorage.getItem('music-muted') === 'true';
+      setMute(saved);
+    </script>
   </body>
 </html>

--- a/views/puzzle.ejs
+++ b/views/puzzle.ejs
@@ -38,12 +38,18 @@
         border: 1px solid #555;
         color: #eee;
       }
+      #toggle-music {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+      }
     </style>
   </head>
   <body>
     <audio id="bg-music" autoplay loop style="display:none">
       <source src="https://cdn.pixabay.com/download/audio/2022/02/18/audio_e963615989.mp3?filename=suspense-6589.mp3" type="audio/mpeg">
     </audio>
+    <button id="toggle-music" class="btn btn-sm btn-outline-light">Silenciar</button>
     <div class="puzzle-container">
       <h1 class="h4 mb-4">Enigma <%= level %></h1>
       <% if (image) { %>
@@ -60,5 +66,17 @@
         </div>
       </form>
     </div>
+    <script>
+      const music = document.getElementById('bg-music');
+      const btn = document.getElementById('toggle-music');
+      function setMute(m) {
+        music.muted = m;
+        btn.textContent = m ? 'Ativar Som' : 'Silenciar';
+        localStorage.setItem('music-muted', m);
+      }
+      btn.addEventListener('click', () => setMute(!music.muted));
+      const saved = localStorage.getItem('music-muted') === 'true';
+      setMute(saved);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add mute button and script for music toggle on all pages

## Testing
- `npm install` *(fails: unable to reach registry)*


------
https://chatgpt.com/codex/tasks/task_e_6872d966de10832db2203c99e7bd3d1b